### PR TITLE
fix: Upgrade the lottie_compose version

### DIFF
--- a/versions.gradle
+++ b/versions.gradle
@@ -25,7 +25,7 @@ versions.foundation = "1.6.0"
 versions.material3 = "1.2.0"
 versions.lifecycle_runtime_ktx = "2.7.0"
 versions.navigation_compose = "2.7.0"
-versions.lottie_compose = "6.1.0"
+versions.lottie_compose = "6.6.6"
 versions.accompanist = "0.34.0"
 
 // Test


### PR DESCRIPTION
我的项目中使用了最新 6.6.6 版本的 lottie_compose，会导致方法找不到，因为下面的原因导致的
Binary compatibility with 6.5 and lower on LottieAnimation [https://github.com/airbnb/lottie-android/pull/2591](url)